### PR TITLE
feat: adopt unified AppHeader (add real header bar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/contact-ui",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Contact form micro-frontend for hadoku.me",
   "type": "module",
   "packageManager": "pnpm@11.5.0",
@@ -58,7 +58,7 @@
     "@typescript-eslint/parser": "^8.47.0",
     "@vitejs/plugin-react": "^5.1.1",
     "@wolffm/logger": "^1.1.0",
-    "@wolffm/task-ui-components": "^2.0.2",
+    "@wolffm/task-ui-components": "^2.1.0",
     "@wolffm/themes": "^3.0.2",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,11 +52,11 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1(vite@7.2.4)
       '@wolffm/task-ui-components':
-        specifier: ^2.0.2
-        version: 2.0.2(react@19.2.0)
+        specifier: ^2.1.0
+        version: 2.1.0(react@19.2.0)
       '@wolffm/themes':
         specifier: ^3.0.2
-        version: 3.0.2(@wolffm/task-ui-components@2.0.2(react@19.2.0))(react@19.2.0)
+        version: 3.0.2(@wolffm/task-ui-components@2.1.0(react@19.2.0))(react@19.2.0)
       eslint:
         specifier: ^9.39.1
         version: 9.39.1
@@ -1607,8 +1607,8 @@ packages:
       react: ^18.0.0 || ^19.0.0
       zod: ^3.25.0 || ^4.0.0
 
-  '@wolffm/task-ui-components@2.0.2':
-    resolution: {integrity: sha512-F529/qfQr2Gwel+Q7N9lK5KI9dmrd8zjP/HtyvoOE/aXb9cSr/CLNioXum5Lp+E7Jiq3xfWK70OVUf1LUhApMw==, tarball: https://npm.pkg.github.com/download/@wolffm/task-ui-components/2.0.2/357aa11338ac81812c3f92135a481ff2ab3521f0}
+  '@wolffm/task-ui-components@2.1.0':
+    resolution: {integrity: sha512-Lz4LfJRVOt6UJQqhb8kg+6sX/rvamVmc35FE5VvbG/hdV+62Kdk+2eH04nzMY7MhyxAe2JhZq9lIIt9Iox8ISg==, tarball: https://npm.pkg.github.com/download/@wolffm/task-ui-components/2.1.0/f917554b4fdb9d856f343aad61c619175c2dcaae}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -4433,13 +4433,13 @@ snapshots:
       react: 19.2.0
       zod: 4.1.12
 
-  '@wolffm/task-ui-components@2.0.2(react@19.2.0)':
+  '@wolffm/task-ui-components@2.1.0(react@19.2.0)':
     dependencies:
       react: 19.2.0
 
-  '@wolffm/themes@3.0.2(@wolffm/task-ui-components@2.0.2(react@19.2.0))(react@19.2.0)':
+  '@wolffm/themes@3.0.2(@wolffm/task-ui-components@2.1.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@wolffm/task-ui-components': 2.0.2(react@19.2.0)
+      '@wolffm/task-ui-components': 2.1.0(react@19.2.0)
       react: 19.2.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import type { ContactUIProps } from './types'
 import ContactForm from './ContactForm'
 import { themePrefs } from './prefs/themePrefs'
 import {
+  AppHeader,
   ThemePicker,
   SunIcon,
   MoonIcon,
@@ -237,7 +238,8 @@ export default function App(props: ContactUIProps = {}) {
       data-dark-theme={isDarkTheme ? 'true' : 'false'}
     >
       <div className="contact-ui">
-        <ContactForm
+        <AppHeader
+          title="Contact"
           themePicker={
             <ThemePicker
               currentTheme={theme}
@@ -254,6 +256,7 @@ export default function App(props: ContactUIProps = {}) {
             />
           }
         />
+        <ContactForm />
       </div>
     </div>
   )

--- a/src/ContactForm.tsx
+++ b/src/ContactForm.tsx
@@ -1,16 +1,12 @@
-import { useState, FormEvent, ChangeEvent, ReactNode, useRef } from 'react'
+import { useState, FormEvent, ChangeEvent, useRef } from 'react'
 import { format } from 'date-fns'
 import { logger } from '@wolffm/logger/client'
 import AppointmentPicker, { type AppointmentPickerRef } from './components/AppointmentPicker'
 import { submitContactWithAppointment, AppointmentAPIError } from './api/appointments'
 import type { FormData, FormErrors, SubmitStatus, AppointmentSelection } from './types'
 
-interface ContactFormProps {
-  themePicker?: ReactNode
-}
-
-export default function ContactForm({ themePicker }: ContactFormProps) {
-  logger.component('update', 'ContactForm', { hasThemePicker: !!themePicker })
+export default function ContactForm() {
+  logger.component('update', 'ContactForm', {})
   const appointmentPickerRef = useRef<AppointmentPickerRef>(null)
 
   const [formData, setFormData] = useState<FormData>({
@@ -213,12 +209,10 @@ export default function ContactForm({ themePicker }: ContactFormProps) {
 
   return (
     <div className="contact-container">
-      {/* Header */}
+      {/* Form hero — the app-level header bar (title + theme + settings) is
+          rendered above by <AppHeader>; this is the form's own heading. */}
       <div className="contact-header">
-        <div className="contact-header__title-row">
-          <h1 className="contact-title">Get in Touch</h1>
-          {themePicker && <div className="contact-header__theme-picker">{themePicker}</div>}
-        </div>
+        <h1 className="contact-title">Get in Touch</h1>
         <p className="contact-subtitle">
           Have a question or want to work together? Send me a message!
         </p>

--- a/src/entry.tsx
+++ b/src/entry.tsx
@@ -4,6 +4,7 @@ import App from './App'
 import type { ContactUIProps } from './types'
 import '@wolffm/themes/style.css'
 import '@wolffm/task-ui-components/theme-picker.css'
+import '@wolffm/task-ui-components/app-header.css'
 import './styles/index.css'
 
 // Re-export all types

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -40,13 +40,6 @@ body {
   padding: 2rem 2rem 0 2rem;
 }
 
-.contact-ui__header-bar {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 1rem;
-  padding: 0.5rem 0;
-}
-
 /* Contact Form Styles */
 .contact-container {
   max-width: 1400px;
@@ -88,18 +81,6 @@ body {
 
 .contact-header {
   margin-bottom: 2rem;
-}
-
-.contact-header__title-row {
-  display: flex;
-  justify-content: flex-start; /* Changed from space-between to flex-start */
-  align-items: center;
-  gap: 1rem; /* Add gap between title and picker */
-  margin-bottom: 0.5rem;
-}
-
-.contact-header__theme-picker {
-  flex-shrink: 0;
 }
 
 .contact-title {


### PR DESCRIPTION
## What

contact-ui had **no top header bar** — the theme picker was threaded into `ContactForm` and rendered **left-aligned** next to the "Get in Touch" heading (the owner's reported symptom). This adds the shared **`AppHeader`** (reference: hadoku-printTool#20) at the app shell.

- `App.tsx`: render `<AppHeader title="Contact" themePicker={<ThemePicker/>} />` above `<ContactForm/>`; stop threading `themePicker` into the form.
- `ContactForm.tsx`: drop the `themePicker` prop; "Get in Touch" stays as the form's own hero heading below the header bar.
- Remove dead `.contact-ui__header-bar` / `.contact-header__title-row` / `.contact-header__theme-picker` CSS.
- The unified **settings gear** (tier · display name · content-visibility level · auth-key swap) is auto-injected by `AppHeader` — contact-ui had none.
- bump `@wolffm/task-ui-components` `^2.0.2 → ^2.1.0`; import `app-header.css`.

## Verification
Typecheck, build (UI + API), eslint, and the `@wolffm/themes` token check all pass against published `2.1.0`. (One pre-existing `exhaustive-deps` warning at App.tsx:202 is unrelated.)